### PR TITLE
Add root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Catalogue des Services Informatique - DRSM IDF
+
+This repository contains the static website for the *Catalogue des Services Informatique* of the DRSM Île-de-France. The site lists the IT services offered internally and provides detailed pages for each service.
+
+All project documentation can be found inside the [`Documentation/`](Documentation/) directory:
+
+- `README.md` &ndash; overview and project goals
+- `CAHIER_DES_CHARGES.md` &ndash; project requirements
+- `CONTENT_UPDATE_GUIDE.md` &ndash; how to edit service pages
+- `DEPLOYMENT.md` &ndash; deployment steps
+- `STYLE_GUIDE.md` &ndash; HTML/CSS conventions
+- `CHANGELOG.md` &ndash; record of changes
+
+## View locally
+
+1. Clone this repository.
+2. Open `index.html` in your web browser to browse the catalogue.
+3. Optionally launch a local server (for example `python -m http.server`) and visit `http://localhost:8000` for a smoother navigation experience.
+


### PR DESCRIPTION
## Summary
- add README at the project root with a short introduction
- list the documentation files under `Documentation/`
- document how to view the static site locally

## Testing
- `git log -1 --stat`